### PR TITLE
Improve RAG pipeline: fix bugs, add validation & docs API

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,24 @@
+# PostgreSQL connection string (matches docker-compose defaults: root/root/postgres)
+DATABASE_URL=postgresql://root:root@localhost:5432/postgres
+
+# AWS S3 configuration (for file storage)
+BUCKET_NAME=your-bucket-name
+APP_AWS_ACCESS_KEY=your-aws-access-key
+APP_AWS_SECRET_KEY=your-aws-secret-key
+APP_AWS_REGION=us-east-1
+
+# JWT authentication
+AUTH_SECRET=change-me-to-a-random-secret-at-least-32-chars
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+HASH_ALGORITHM=HS256
+
+# Chainlit authentication secret
+CHAINLIT_AUTH_SECRET=change-me-to-another-random-secret
+
+# vLLM model configuration (used by vllmconfig/vllminit.sh)
+HF_TOKEN=your-huggingface-token
+MODEL=Qwen/Qwen3-VL-8B-Instruct
+
+# ChromaDB (optional, defaults shown)
+# CHROMA_HOST=localhost
+# CHROMA_PORT=8003

--- a/src/chainlit-app.py
+++ b/src/chainlit-app.py
@@ -111,15 +111,19 @@ async def on_message(cl_msg: cl.Message):
 
     if DOCS:
         for doc in DOCS:
-            ingestion.ingest_file(
+            count, error = ingestion.ingest_file(
                 file_path=doc.path,
                 file_id=doc.id,
                 file_name=doc.name,
                 file_type=doc.mime,
                 user_id=user_id,
             )
+            if error:
+                await cl.Message(content=f"⚠️ {error}").send()
+            elif count > 0:
+                await cl.Message(content=f"✅ Ingested **{doc.name}** ({count} chunks)").send()
 
-    context_str = retrieval.get_context(cl_msg.content, user_id)
+    context_str, sources = retrieval.get_context(cl_msg.content, user_id)
 
     final_query = cl_msg.content
     if context_str:

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 from src.core.config import Settings

--- a/src/routers/adminrouter.py
+++ b/src/routers/adminrouter.py
@@ -3,22 +3,22 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from src.db.database import engine, get_db
+from src.db.database import get_db
 from src.models.user import UserResponse, UserUpdate
-from src.services.adminservice import get_users, get_user_by_id
+from src.services import adminservice
 
 AdminRouter = APIRouter(prefix="/admin", tags=["admin"])
 
 
 @AdminRouter.get("/users/")
 async def read_users(db: Session = Depends(get_db)):
-    return get_users(db=db)
+    return adminservice.get_users(db=db)
 
 
 @AdminRouter.get("/users/{userId}", response_model=UserResponse)
-async def get_user_by_id(userId: UUID, db: Session = Depends(get_db)):
+async def read_user_by_id(userId: UUID, db: Session = Depends(get_db)):
     """Get a user by their ID."""
-    user = get_user_by_id(userId, db)
+    user = adminservice.get_user_by_id(userId, db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
@@ -27,11 +27,11 @@ async def get_user_by_id(userId: UUID, db: Session = Depends(get_db)):
 
 
 @AdminRouter.put("/users/{userId}", response_model=UserResponse)
-async def update_user(
+async def update_user_by_id(
     userId: UUID, user_update: UserUpdate, db: Session = Depends(get_db)
 ):
     """Update a user's fields."""
-    user = get_user_by_id(userId, db)
+    user = adminservice.get_user_by_id(userId, db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
@@ -49,7 +49,7 @@ async def update_user(
             )
 
     try:
-        updated_user = update_user(
+        updated_user = adminservice.update_user(
             userId, user_update.model_dump(exclude_unset=True), db
         )
         return updated_user
@@ -60,13 +60,13 @@ async def update_user(
 
 
 @AdminRouter.delete("/users/{userId}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_user(userId: UUID, db: Session = Depends(get_db)):
+async def delete_user_by_id(userId: UUID, db: Session = Depends(get_db)):
     """Delete a user from the database."""
-    user = get_user_by_id(userId, db)
+    user = adminservice.get_user_by_id(userId, db)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    delete_user(userId, db)
+    adminservice.delete_user(userId, db)
     return None

--- a/src/routers/docsrouter.py
+++ b/src/routers/docsrouter.py
@@ -1,0 +1,63 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from src.schema.models import User
+from src.services.authservice import get_current_active_user
+from src.services.ragutils.vector_db import get_vector_db
+
+DocsRouter = APIRouter(prefix="/docs", tags=["documents"])
+
+db = get_vector_db()
+
+
+class DocumentInfo(BaseModel):
+    file_name: str
+    file_id: str
+    chunk_count: int
+
+
+@DocsRouter.get("/", response_model=list[DocumentInfo])
+async def list_documents(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    """List all documents uploaded by the current user."""
+    results = db.collection.get(
+        where={"user_id": current_user.identifier},
+    )
+
+    file_map: dict[str, DocumentInfo] = {}
+    for meta in results["metadatas"]:
+        fid = meta["source_file_id"]
+        if fid not in file_map:
+            file_map[fid] = DocumentInfo(
+                file_name=meta["file_name"],
+                file_id=fid,
+                chunk_count=0,
+            )
+        file_map[fid].chunk_count += 1
+
+    return list(file_map.values())
+
+
+@DocsRouter.delete("/{file_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document(
+    file_id: str,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    """Delete a document and all its chunks from the vector database."""
+    # Verify the file belongs to this user
+    results = db.collection.get(
+        where={"$and": [{"source_file_id": file_id}, {"user_id": current_user.identifier}]},
+        limit=1,
+    )
+
+    if not results["ids"]:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found or not owned by you.",
+        )
+
+    db.delete_file(file_id)
+    return None

--- a/src/server.py
+++ b/src/server.py
@@ -11,6 +11,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from src.core.core import oauth2_scheme
 from src.routers.adminrouter import AdminRouter
 from src.routers.authrouter import AuthRouter
+from src.routers.docsrouter import DocsRouter
 from src.services.authservice import require_roles
 from src.schema.models import UserRole
 
@@ -21,6 +22,10 @@ app.include_router(AuthRouter)
 app.include_router(
     AdminRouter,
     dependencies=[Depends(oauth2_scheme), Depends(require_roles(UserRole.admin))],
+)
+app.include_router(
+    DocsRouter,
+    dependencies=[Depends(oauth2_scheme)],
 )
 mount_chainlit(app=app, target="./chainlit-app.py", path="/gllm")
 

--- a/src/services/adminservice.py
+++ b/src/services/adminservice.py
@@ -9,7 +9,7 @@ from src.schema.models import User, UserRole
 from src.db.database import get_db
 
 
-def get_users(self, db: Session) -> list[User]:
+def get_users(db: Session) -> list[User]:
     """
     Returns all users.
 

--- a/src/services/ragutils/ingestion.py
+++ b/src/services/ragutils/ingestion.py
@@ -1,43 +1,68 @@
+import logging
+import os
+
 from langchain_community.document_loaders import PyPDFLoader, TextLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter, Language
 
 from src.services.ragutils.vector_db import get_vector_db
 
+logger = logging.getLogger(__name__)
 
 db = get_vector_db()
 
+MAX_FILE_SIZE_MB = 50
+SUPPORTED_TEXT_EXTENSIONS = {".py", ".txt", ".md", ".csv", ".json", ".xml", ".html", ".css", ".js", ".ts", ".yaml", ".yml"}
+
+
+def validate_file(file_path, file_name, file_type):
+    """Validate file size and type before ingestion."""
+    file_size_mb = os.path.getsize(file_path) / (1024 * 1024)
+    if file_size_mb > MAX_FILE_SIZE_MB:
+        raise ValueError(
+            f"File '{file_name}' is {file_size_mb:.1f}MB, exceeding the {MAX_FILE_SIZE_MB}MB limit."
+        )
+
+    ext = os.path.splitext(file_name)[1].lower()
+    if file_type != "application/pdf" and ext not in SUPPORTED_TEXT_EXTENSIONS:
+        raise ValueError(
+            f"Unsupported file type: '{ext}'. Supported: PDF, {', '.join(sorted(SUPPORTED_TEXT_EXTENSIONS))}"
+        )
+
+
+def is_duplicate(file_name, user_id):
+    """Check if a file with the same name has already been ingested by this user."""
+    results = db.collection.get(
+        where={"$and": [{"user_id": user_id}, {"file_name": file_name}]},
+        limit=1,
+    )
+    return len(results["ids"]) > 0
+
 
 def ingest_file(file_path, file_id, file_name, file_type, user_id):
+    """Ingest a file into the vector database with validation and error handling."""
 
-    print(file_path, file_name, file_type)
-    docs = []
+    try:
+        validate_file(file_path, file_name, file_type)
+    except ValueError as e:
+        logger.warning("File validation failed: %s", e)
+        return 0, str(e)
 
-    if file_type == "application/pdf":
-        loader = PyPDFLoader(file_path)
-        raw_docs = loader.load()
+    if is_duplicate(file_name, user_id):
+        msg = f"File '{file_name}' has already been ingested. Skipping duplicate."
+        logger.info(msg)
+        return 0, msg
 
-        for doc in raw_docs:
-            if "page" in doc.metadata:
-                doc.metadata["page_number"] = doc.metadata["page"] + 1
-            else:
-                doc.metadata["page_number"] = 1
+    try:
+        docs = _load_and_split(file_path, file_name, file_type)
+    except Exception as e:
+        msg = f"Failed to process file '{file_name}': {e}"
+        logger.error(msg)
+        return 0, msg
 
-        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
-        docs = splitter.split_documents(raw_docs)
-
-    else:
-        loader = TextLoader(file_path)
-        raw_docs = loader.load()
-        lang = Language.PYTHON if ".py" in file_name else Language.MARKDOWN
-        print(f"inside lang block, lang is {lang}")
-
-        splitter = RecursiveCharacterTextSplitter.from_language(
-            language=lang, chunk_size=1000, chunk_overlap=100
-        )
-        docs = splitter.split_documents(raw_docs)
-
-        for doc in docs:
-            doc.metadata["page_number"] = 1
+    if not docs:
+        msg = f"No content extracted from '{file_name}'."
+        logger.warning(msg)
+        return 0, msg
 
     ids = []
     documents = []
@@ -56,5 +81,44 @@ def ingest_file(file_path, file_id, file_name, file_type, user_id):
         documents.append(chunk.page_content)
         metadatas.append(meta)
 
-    db.insert_chunks(ids, documents, metadatas)
-    return len(ids)
+    try:
+        db.insert_chunks(ids, documents, metadatas)
+    except Exception as e:
+        msg = f"Failed to store chunks for '{file_name}': {e}"
+        logger.error(msg)
+        return 0, msg
+
+    logger.info("Ingested '%s': %d chunks", file_name, len(ids))
+    return len(ids), None
+
+
+def _load_and_split(file_path, file_name, file_type):
+    """Load a file and split it into chunks."""
+
+    if file_type == "application/pdf":
+        loader = PyPDFLoader(file_path)
+        raw_docs = loader.load()
+
+        for doc in raw_docs:
+            if "page" in doc.metadata:
+                doc.metadata["page_number"] = doc.metadata["page"] + 1
+            else:
+                doc.metadata["page_number"] = 1
+
+        splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+        docs = splitter.split_documents(raw_docs)
+
+    else:
+        loader = TextLoader(file_path)
+        raw_docs = loader.load()
+        lang = Language.PYTHON if file_name.endswith(".py") else Language.MARKDOWN
+
+        splitter = RecursiveCharacterTextSplitter.from_language(
+            language=lang, chunk_size=1000, chunk_overlap=100
+        )
+        docs = splitter.split_documents(raw_docs)
+
+        for doc in docs:
+            doc.metadata["page_number"] = 1
+
+    return docs

--- a/src/services/ragutils/retrieval.py
+++ b/src/services/ragutils/retrieval.py
@@ -1,4 +1,8 @@
+import logging
+
 from src.services.ragutils.vector_db import get_vector_db
+
+logger = logging.getLogger(__name__)
 
 db = get_vector_db()
 
@@ -9,15 +13,20 @@ def get_context(query_text, user_id, n_results=5):
     Returns: (formatted_context_string, list_of_sources)
     """
 
-    results = db.search(query_text, user_id, n_results)
+    try:
+        results = db.search(query_text, user_id, n_results)
+    except Exception as e:
+        logger.error("Vector DB search failed: %s", e)
+        return None, []
+
     context_string = ""
     sources = []
 
-    if results["documents"]:
+    if results and results.get("documents"):
         docs = results["documents"][0]
         metas = results["metadatas"][0]
 
-        for i, (text, meta) in enumerate(zip(docs, metas)):
+        for text, meta in zip(docs, metas):
             citation = f"[Source: {meta['file_name']} | Page: {meta['page_number']}]"
             context_string += f"{citation}\n{text}\n\n"
             if meta["file_name"] not in sources:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,36 +1,16 @@
-import pytest
 import os
 import sys
-from dotenv import load_dotenv
 
-# 1. Add 'src' to the python path
-src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../src'))
+# Add src to the python path
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
 sys.path.insert(0, src_path)
 
-# 2. Load the .env file explicitly
-env_path = os.path.join(src_path, '.env')
-load_dotenv(env_path)
+# Optionally load .env if it exists (for local dev with services running)
+try:
+    from dotenv import load_dotenv
 
-@pytest.fixture(autouse=True)
-def mock_env_vars(monkeypatch):
-    """
-    Sets defaults for tests, but allows real .env values to override if present.
-    """
-    if not os.getenv("APP_USER"):
-        monkeypatch.setenv("APP_USER", "test_admin")
-    if not os.getenv("APP_PASS"):
-        monkeypatch.setenv("APP_PASS", "test_pass")
-        
-    # Always force a dummy prompt path for unit tests
-    monkeypatch.setenv("SYSTEM_PROMPT_PATH", "./tests/dummy_prompt.txt")
-
-@pytest.fixture
-def dummy_prompt_file(tmp_path):
-    """
-    Creates a temporary system prompt file for testing PromptManager.
-    """
-    d = tmp_path / "Prompts"
-    d.mkdir()
-    p = d / "System.txt"
-    p.write_text("You are a test AI.")
-    return str(p)
+    env_path = os.path.join(src_path, ".env")
+    if os.path.exists(env_path):
+        load_dotenv(env_path)
+except ImportError:
+    pass

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,223 @@
+"""Unit tests for the RAG pipeline (ingestion, retrieval, vector_db)."""
+
+import os
+import sys
+import importlib
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Add src to path
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
+sys.path.insert(0, src_path)
+
+
+@pytest.fixture
+def mock_db():
+    """Patch get_vector_db before importing ingestion/retrieval modules."""
+    mock = MagicMock()
+    mock.collection = MagicMock()
+
+    with patch("src.services.ragutils.vector_db.get_vector_db", return_value=mock):
+        # Force re-import so module-level db = get_vector_db() uses the mock
+        import src.services.ragutils.ingestion as ingestion_mod
+        import src.services.ragutils.retrieval as retrieval_mod
+
+        ingestion_mod.db = mock
+        retrieval_mod.db = mock
+
+        yield mock, ingestion_mod, retrieval_mod
+
+
+# --- Ingestion Tests ---
+
+
+class TestValidateFile:
+    """Tests for file validation logic."""
+
+    def test_rejects_oversized_file(self, tmp_path, mock_db):
+        _, ingestion, _ = mock_db
+
+        large_file = tmp_path / "big.pdf"
+        large_file.write_bytes(b"x" * (ingestion.MAX_FILE_SIZE_MB * 1024 * 1024 + 1))
+
+        with pytest.raises(ValueError, match="exceeding the"):
+            ingestion.validate_file(str(large_file), "big.pdf", "application/pdf")
+
+    def test_accepts_valid_pdf(self, tmp_path, mock_db):
+        _, ingestion, _ = mock_db
+
+        small_file = tmp_path / "small.pdf"
+        small_file.write_bytes(b"x" * 1000)
+
+        ingestion.validate_file(str(small_file), "small.pdf", "application/pdf")
+
+    def test_rejects_unsupported_extension(self, tmp_path, mock_db):
+        _, ingestion, _ = mock_db
+
+        bad_file = tmp_path / "file.exe"
+        bad_file.write_bytes(b"x" * 100)
+
+        with pytest.raises(ValueError, match="Unsupported file type"):
+            ingestion.validate_file(str(bad_file), "file.exe", "application/octet-stream")
+
+    def test_accepts_supported_text_extensions(self, tmp_path, mock_db):
+        _, ingestion, _ = mock_db
+
+        for ext in ingestion.SUPPORTED_TEXT_EXTENSIONS:
+            f = tmp_path / f"test{ext}"
+            f.write_bytes(b"content")
+            ingestion.validate_file(str(f), f"test{ext}", "text/plain")
+
+
+class TestIsDuplicate:
+    """Tests for duplicate detection."""
+
+    def test_detects_duplicate(self, mock_db):
+        db_mock, ingestion, _ = mock_db
+        db_mock.collection.get.return_value = {"ids": ["existing_id"]}
+
+        assert ingestion.is_duplicate("report.pdf", "user123") is True
+
+    def test_no_duplicate(self, mock_db):
+        db_mock, ingestion, _ = mock_db
+        db_mock.collection.get.return_value = {"ids": []}
+
+        assert ingestion.is_duplicate("new_file.pdf", "user123") is False
+
+
+class TestIngestFile:
+    """Tests for the main ingest_file function."""
+
+    def test_successful_ingestion(self, tmp_path, mock_db):
+        db_mock, ingestion, _ = mock_db
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        # No duplicate
+        db_mock.collection.get.return_value = {"ids": []}
+
+        # Mock load_and_split
+        mock_chunk = MagicMock()
+        mock_chunk.page_content = "hello world"
+        mock_chunk.metadata = {"page_number": 1}
+
+        with patch.object(ingestion, "_load_and_split", return_value=[mock_chunk]):
+            count, error = ingestion.ingest_file(
+                str(test_file), "file123", "test.txt", "text/plain", "user1"
+            )
+
+        assert count == 1
+        assert error is None
+        db_mock.insert_chunks.assert_called_once()
+
+    def test_skips_duplicate(self, tmp_path, mock_db):
+        db_mock, ingestion, _ = mock_db
+
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        db_mock.collection.get.return_value = {"ids": ["existing"]}
+
+        count, error = ingestion.ingest_file(
+            str(test_file), "file123", "test.txt", "text/plain", "user1"
+        )
+
+        assert count == 0
+        assert "already been ingested" in error
+        db_mock.insert_chunks.assert_not_called()
+
+    def test_rejects_oversized_file(self, tmp_path, mock_db):
+        _, ingestion, _ = mock_db
+
+        big_file = tmp_path / "huge.pdf"
+        big_file.write_bytes(b"x" * (ingestion.MAX_FILE_SIZE_MB * 1024 * 1024 + 1))
+
+        count, error = ingestion.ingest_file(
+            str(big_file), "file123", "huge.pdf", "application/pdf", "user1"
+        )
+
+        assert count == 0
+        assert "exceeding" in error
+
+    def test_handles_load_error(self, tmp_path, mock_db):
+        db_mock, ingestion, _ = mock_db
+
+        test_file = tmp_path / "bad.txt"
+        test_file.write_text("content")
+
+        db_mock.collection.get.return_value = {"ids": []}
+
+        with patch.object(ingestion, "_load_and_split", side_effect=Exception("parse error")):
+            count, error = ingestion.ingest_file(
+                str(test_file), "file123", "bad.txt", "text/plain", "user1"
+            )
+
+        assert count == 0
+        assert "Failed to process" in error
+
+
+# --- Retrieval Tests ---
+
+
+class TestGetContext:
+    """Tests for context retrieval."""
+
+    def test_returns_formatted_context(self, mock_db):
+        db_mock, _, retrieval = mock_db
+
+        db_mock.search.return_value = {
+            "documents": [["chunk1 text", "chunk2 text"]],
+            "metadatas": [
+                [
+                    {"file_name": "report.pdf", "page_number": 1},
+                    {"file_name": "report.pdf", "page_number": 2},
+                ],
+            ],
+        }
+
+        context, sources = retrieval.get_context("what is AI?", "user1")
+
+        assert context is not None
+        assert "[Source: report.pdf | Page: 1]" in context
+        assert "[Source: report.pdf | Page: 2]" in context
+        assert "chunk1 text" in context
+        assert sources == ["report.pdf"]
+
+    def test_returns_none_when_no_results(self, mock_db):
+        db_mock, _, retrieval = mock_db
+
+        db_mock.search.return_value = {"documents": [[]], "metadatas": [[]]}
+
+        context, sources = retrieval.get_context("unknown query", "user1")
+
+        assert context is None
+        assert sources == []
+
+    def test_handles_search_error_gracefully(self, mock_db):
+        db_mock, _, retrieval = mock_db
+
+        db_mock.search.side_effect = Exception("Connection refused")
+
+        context, sources = retrieval.get_context("test query", "user1")
+
+        assert context is None
+        assert sources == []
+
+    def test_deduplicates_sources(self, mock_db):
+        db_mock, _, retrieval = mock_db
+
+        db_mock.search.return_value = {
+            "documents": [["chunk1", "chunk2", "chunk3"]],
+            "metadatas": [
+                [
+                    {"file_name": "a.pdf", "page_number": 1},
+                    {"file_name": "a.pdf", "page_number": 2},
+                    {"file_name": "b.pdf", "page_number": 1},
+                ],
+            ],
+        }
+
+        context, sources = retrieval.get_context("query", "user1")
+
+        assert sources == ["a.pdf", "b.pdf"]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,78 +1,165 @@
+"""Unit tests for auth service, admin service, and prompt service."""
+
 import os
-import socket
+import sys
 import json
+import socket
 import pytest
-import httpx
-from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from AuthHandler.AuthHandler import AuthHandler
-from PromptManager.PromptManager import PromptManager
+# Add src to path
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
+sys.path.insert(0, src_path)
 
-# TC-1.1 / TC-1.2: auth singleton + login callback (app uses credentials "admin"/"admin")
-def test_auth_singleton():
-    auth1 = AuthHandler()
-    auth2 = AuthHandler()
-    assert auth1 is auth2
+ENV_OVERRIDES = {
+    "AUTH_SECRET": "test-secret-key",
+    "HASH_ALGORITHM": "HS256",
+    "ACCESS_TOKEN_EXPIRE_MINUTES": "30",
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "BUCKET_NAME": "test",
+    "APP_AWS_ACCESS_KEY": "test",
+    "APP_AWS_SECRET_KEY": "test",
+    "APP_AWS_REGION": "us-east-1",
+    "CHAINLIT_AUTH_SECRET": "test",
+}
 
-def test_system_prompt_loading(dummy_prompt_file):
-    pm = PromptManager()
-    pm.promptsDir = str(Path(dummy_prompt_file).parent)
-    assert pm.getSystem().strip() == "You are a test AI."
 
-@pytest.mark.skipif(os.getenv("TEST_PROMPT_FALLBACK") != "1", reason="Fallback behaviour not enabled")
-def test_system_prompt_fallback(tmp_path, monkeypatch):
-    """
-    TC-2.2: Only run if TEST_PROMPT_FALLBACK=1. Requires PromptManager to implement a fallback.
-    """
-    # Remove System.txt and expect a fallback to be returned (implementation dependent).
-    d = tmp_path / "Prompts"
-    d.mkdir()
-    monkeypatch.setenv("SYSTEM_PROMPT_PATH", str(d))
-    pm = PromptManager()
-    pm.promptsDir = str(d)
-    # If implementation supports fallback it should return a non-empty string
-    fallback = pm.getSystem()
-    assert isinstance(fallback, str)
-    assert fallback.strip() != ""
+# --- Auth Service Tests ---
+
+
+class TestPasswordHashing:
+    """TC-1.1: Password hashing and verification."""
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_hash_and_verify_password(self):
+        from src.services.authservice import get_password_hash, verify_password
+
+        password = "securepassword123"
+        hashed = get_password_hash(password)
+
+        assert hashed != password
+        assert verify_password(password, hashed) is True
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_wrong_password_fails(self):
+        from src.services.authservice import get_password_hash, verify_password
+
+        hashed = get_password_hash("correct_password")
+        assert verify_password("wrong_password", hashed) is False
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_different_passwords_produce_different_hashes(self):
+        from src.services.authservice import get_password_hash
+
+        hash1 = get_password_hash("password1")
+        hash2 = get_password_hash("password2")
+        assert hash1 != hash2
+
+
+class TestAccessToken:
+    """TC-1.2: JWT token creation and validation."""
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_create_access_token(self):
+        import jwt
+        from src.services.authservice import create_access_token
+
+        token = create_access_token(data={"sub": "testuser"})
+
+        assert isinstance(token, str)
+        decoded = jwt.decode(token, "test-secret-key", algorithms=["HS256"])
+        assert decoded["sub"] == "testuser"
+        assert "exp" in decoded
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_token_with_custom_expiration(self):
+        import jwt
+        from datetime import timedelta
+        from src.services.authservice import create_access_token
+
+        token = create_access_token(
+            data={"sub": "testuser"},
+            expires_delta=timedelta(minutes=60),
+        )
+
+        decoded = jwt.decode(token, "test-secret-key", algorithms=["HS256"])
+        assert "exp" in decoded
+
+
+class TestSignupUser:
+    """TC-1.3: User signup validation."""
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_signup_rejects_duplicate_user(self):
+        from src.services.authservice import signup_user
+        from src.models.user import UserCreate
+
+        mock_db = MagicMock()
+        mock_db.scalar.return_value = MagicMock()  # Existing user found
+
+        user_in = UserCreate(identifier="existinguser", password="pass123")
+
+        with pytest.raises(ValueError, match="User already exists"):
+            signup_user(db=mock_db, user_in=user_in)
+
+
+# --- Prompt Service Tests ---
+
+
+class TestPromptService:
+    """TC-2.1: System prompt loading."""
+
+    def test_get_system_returns_nonempty_string(self):
+        from src.services.promptservice import get_system
+
+        prompt = get_system()
+
+        assert isinstance(prompt, str)
+        assert len(prompt.strip()) > 0
+
+    def test_system_prompt_contains_research_context(self):
+        from src.services.promptservice import get_system
+
+        prompt = get_system()
+
+        assert "research" in prompt.lower()
+
+
+# --- JSON Parsing Tests ---
+
 
 def test_json_parsing_of_inference_response():
-    """
-    TC-2.3: Ensure system code can parse JSON responses when LLM returns JSON string.
-    This is a basic unit test of json.loads usage rather than a full streaming parser test.
-    """
+    """TC-2.3: Ensure system code can parse JSON responses from LLM."""
     payload = '{"answer": "42", "confidence": 0.99}'
     parsed = json.loads(payload)
     assert parsed["answer"] == "42"
     assert parsed["confidence"] == 0.99
 
-@pytest.mark.live
+
+# --- Connectivity Tests (conditional, require services running) ---
+
+
+@pytest.mark.skipif(os.getenv("RUN_LIVE_TESTS") != "1", reason="Live tests disabled")
 def test_vllm_connectivity_http():
-    """
-    TC-2.4: Verifies connectivity via HTTP.
-    """
+    """TC-2.4: Verifies connectivity to vLLM via HTTP."""
+    import httpx
+
     url = "http://localhost:8000/v1/models"
-    
     try:
         response = httpx.get(url, timeout=5)
-        # 200 OK means the server is actually happy and running
         assert response.status_code == 200
-        # Ensure we got valid JSON back
         data = response.json()
         assert "data" in data
     except httpx.RequestError as e:
         pytest.fail(f"Could not connect to vLLM: {e}")
 
-# TC-1.3: DB connectivity (separate test)
+
 @pytest.mark.skipif(os.getenv("RUN_DB_TESTS") != "1", reason="DB tests disabled")
 def test_db_tcp_connectivity():
-    """
-    TC-1.3: Lightweight connectivity check for Database host/port parsed from DATABASE_URL.
-    Set RUN_DB_TESTS=1 and ensure DATABASE_URL exists in env.
-    """
+    """TC-1.3: Lightweight connectivity check for PostgreSQL."""
     db_url = os.getenv("DATABASE_URL")
-    assert db_url, "DATABASE_URL must be set to run DB connectivity test"
+    assert db_url, "DATABASE_URL must be set"
 
-    # crude parse: postgres://user:pass@host:port/db
     try:
         hostport = db_url.split("@")[1].split("/")[0]
         host, port = hostport.split(":")
@@ -80,7 +167,6 @@ def test_db_tcp_connectivity():
     except Exception as e:
         pytest.skip(f"Unable to parse DATABASE_URL: {e}")
 
-    # attempt TCP connect to DB host
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(3.0)
@@ -89,17 +175,12 @@ def test_db_tcp_connectivity():
         pytest.fail(f"Could not connect to DB host {host}:{port} - {e}")
 
 
-# TC-1.4: S3/MinIO connectivity (separate test)
 @pytest.mark.skipif(os.getenv("RUN_S3_TESTS") != "1", reason="S3 tests disabled")
 def test_s3_tcp_connectivity():
-    """
-    TC-1.4: Lightweight connectivity check for S3 endpoint host/port.
-    Set RUN_S3_TESTS=1 and ensure S3_ENDPOINT or S3_URL exists in env.
-    """
+    """TC-1.4: Lightweight connectivity check for S3 endpoint."""
     s3_endpoint = os.getenv("S3_ENDPOINT") or os.getenv("S3_URL") or os.getenv("BUCKET_ENDPOINT")
-    assert s3_endpoint, "S3_ENDPOINT or S3_URL (or BUCKET_ENDPOINT) must be set to run S3 connectivity test"
+    assert s3_endpoint, "S3_ENDPOINT or S3_URL must be set"
 
-    # parse s3 host:port if present
     if "://" in s3_endpoint:
         s3_hostport = s3_endpoint.split("://")[1].split("/")[0]
     else:
@@ -110,9 +191,8 @@ def test_s3_tcp_connectivity():
         s3_port = int(s3_port)
     except ValueError:
         s3_host = s3_hostport
-        s3_port = 9000  # default (minio) fallback
+        s3_port = 9000
 
-    # attempt TCP connect to S3 host
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2:
             s2.settimeout(3.0)


### PR DESCRIPTION
## Summary

### RAG Pipeline Improvements (Issue #15)
- **Fix critical bug**: `get_context()` returns a tuple `(context_str, sources)` but only one variable captured it in `chainlit-app.py`, causing malformed LLM prompts
- **Add file validation**: 50MB size limit, supported file type checking, duplicate document detection
- **Add error handling**: try/catch with logging throughout ingestion and retrieval pipelines
- **Add `/docs` API**: new endpoints for listing (`GET /docs/`) and deleting (`DELETE /docs/{file_id}`) user documents
- **Add user feedback**: chat messages confirming ingestion success/failure/duplicate

### Admin Router Bug Fixes
- **Fix 3 infinite recursion bugs**: route handler functions `get_user_by_id`, `update_user`, and `delete_user` shadowed their imported service functions — calling themselves recursively instead of the service layer
- **Fix stray `self` parameter** in `adminservice.get_users()` (not a class method)

### Developer Experience
- **Add `.env.example`** with documented defaults matching docker-compose
- **Fix deprecated import** in `database.py` (`declarative_base`)

### Test Suite
- **Rewrite `test_unit.py`**: was importing deleted `AuthHandler`/`PromptManager` modules (all unit tests were broken). Now tests auth service, prompt service, and JWT creation
- **Add `test_rag.py`**: 14 new unit tests for ingestion validation, duplicate detection, retrieval formatting, and error handling
- **Simplify `conftest.py`**: no longer requires `dotenv` at import time
- **Result: 26 passed, 4 skipped (require running services), 0 failed**

Relates to #15 (Implement MVP RAG pipeline based on ChromaDB)

## Changes
| File | What changed |
|------|-------------|
| `src/chainlit-app.py` | Fixed tuple unpacking, added ingestion feedback messages |
| `src/services/ragutils/ingestion.py` | Added `validate_file()`, `is_duplicate()`, error handling, logging |
| `src/services/ragutils/retrieval.py` | Added error handling, safer dict access, logging |
| `src/routers/docsrouter.py` | **New** — REST API for document management |
| `src/routers/adminrouter.py` | Fixed 3 infinite recursion bugs (name shadowing) |
| `src/services/adminservice.py` | Fixed stray `self` parameter |
| `src/db/database.py` | Fixed deprecated `declarative_base` import |
| `src/server.py` | Registered DocsRouter |
| `src/.env.example` | **New** — documented env template |
| `tests/test_rag.py` | **New** — 14 RAG pipeline unit tests |
| `tests/test_unit.py` | Rewritten for current codebase |
| `tests/conftest.py` | Simplified, removed hard dotenv dependency |

## Test plan
- [x] All 26 tests pass (`pytest tests/ -v`)
- [ ] Manual test: upload a PDF via chat, verify ingestion feedback
- [ ] Manual test: upload same PDF again, verify duplicate detection
- [ ] Manual test: upload file > 50MB, verify rejection
- [ ] Manual test: `GET /docs/` returns user's documents
- [ ] Manual test: `DELETE /docs/{file_id}` removes document chunks
- [ ] Manual test: admin endpoints (`GET/PUT/DELETE /admin/users/`) work without recursion

🤖 Generated with [Claude Code](https://claude.com/claude-code)