### PR TITLE
Add fine-tuning pipeline with Unsloth + LoRA

### DIFF
--- a/finetune/.gitignore
+++ b/finetune/.gitignore
@@ -1,0 +1,6 @@
+lora_adapter/
+merged_model/
+outputs/
+*.pt
+*.safetensors
+*.bin

--- a/finetune/README.md
+++ b/finetune/README.md
@@ -1,0 +1,79 @@
+# Fine-Tuning with Unsloth + LoRA
+
+Fine-tune LLMs using [Unsloth](https://unsloth.ai/) with LoRA adapters, then serve them via vLLM.
+
+## Prerequisites
+
+- Docker with NVIDIA Container Toolkit
+- NVIDIA GPU (16GB+ VRAM recommended)
+- `HF_TOKEN` environment variable (for downloading gated models / pushing adapters)
+
+## Quick Start
+
+1. **Edit the config** — copy `config.yaml` and adjust model, dataset, and training params:
+   ```bash
+   cp config.yaml my_config.yaml
+   # Edit my_config.yaml
+   ```
+
+2. **Run fine-tuning**:
+   ```bash
+   ./run_finetune.sh my_config.yaml
+   ```
+
+3. **Serve with LoRA** — start vLLM with adapter support:
+   ```bash
+   ../vllmconfig/vllminit_lora.sh ./lora_adapter
+   ```
+
+4. **Or load adapters at runtime** via the API:
+   ```bash
+   # Start vLLM with LoRA enabled (no adapter loaded yet)
+   ../vllmconfig/vllminit_lora.sh
+
+   # Load adapter via API
+   curl -X POST http://localhost:8000/v1/load_lora_adapter \
+     -H "Content-Type: application/json" \
+     -d '{"lora_name": "my_adapter", "lora_path": "/adapters/default"}'
+
+   # Use the adapter in chat
+   curl http://localhost:8000/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"model": "my_adapter", "messages": [{"role": "user", "content": "Hello"}]}'
+   ```
+
+## Configuration
+
+See `config.yaml` for all available options:
+
+| Section | Key Options |
+|---------|-------------|
+| `model` | `name`, `max_seq_length`, `load_in_4bit` |
+| `lora` | `r` (rank), `lora_alpha`, `target_modules` |
+| `dataset` | `source` (HF name or local file), column mappings, `prompt_template` |
+| `training` | `batch_size`, `num_epochs`, `learning_rate`, `optimizer` |
+| `save` | `local_path`, `hf_repo` (push to HuggingFace), `save_merged` |
+
+## Backend API
+
+The gLLM backend exposes endpoints for managing adapters (requires `fine_tuner` or `admin` role):
+
+- `GET /finetune/adapters` — list available adapters on disk
+- `POST /finetune/adapters/load` — load an adapter into vLLM
+- `POST /finetune/adapters/unload` — unload an adapter from vLLM
+
+## Custom Datasets
+
+Prepare your dataset as JSON with `instruction`, `input`, `output` fields:
+
+```json
+[
+  {
+    "instruction": "Summarize the following text",
+    "input": "Long text here...",
+    "output": "Summary here..."
+  }
+]
+```
+
+Then set `source: "path/to/your_data.json"` in the config.

--- a/finetune/config.yaml
+++ b/finetune/config.yaml
@@ -1,0 +1,76 @@
+# gLLM Fine-Tuning Configuration
+# Copy this file and modify for your use case.
+
+model:
+  # HuggingFace model name or local path
+  name: "unsloth/Qwen2.5-7B-bnb-4bit"
+  max_seq_length: 2048
+  load_in_4bit: true  # QLoRA (recommended for memory efficiency)
+
+lora:
+  r: 16                # LoRA rank (8, 16, 32, 64)
+  lora_alpha: 16       # Scaling factor (typically same as r)
+  target_modules:      # Which layers to apply LoRA to
+    - q_proj
+    - k_proj
+    - v_proj
+    - o_proj
+    - gate_proj
+    - up_proj
+    - down_proj
+  random_state: 3407
+
+dataset:
+  # HuggingFace dataset name OR local file path (.json, .jsonl, .csv)
+  source: "yahma/alpaca-cleaned"
+  split: "train"
+
+  # Column mappings (adjust to match your dataset)
+  instruction_column: "instruction"
+  input_column: "input"
+  output_column: "output"
+
+  # Optional: limit dataset size for testing
+  # max_samples: 1000
+
+  # Prompt template (uses {instruction}, {input}, {output} placeholders)
+  prompt_template: |
+    Below is an instruction that describes a task, paired with an input
+    that provides further context. Write a response that appropriately
+    completes the request.
+
+    ### Instruction:
+    {instruction}
+
+    ### Input:
+    {input}
+
+    ### Response:
+    {output}
+
+training:
+  batch_size: 2
+  gradient_accumulation_steps: 4
+  warmup_steps: 5
+  num_epochs: 3
+  # max_steps: 100          # Uncomment to override num_epochs
+  learning_rate: 2e-4
+  optimizer: "adamw_8bit"
+  weight_decay: 0.01
+  lr_scheduler: "linear"
+  logging_steps: 10
+  save_strategy: "epoch"
+  output_dir: "./outputs"
+  seed: 3407
+
+save:
+  # Local path for LoRA adapter files (~100MB)
+  local_path: "./lora_adapter"
+
+  # Optionally save full merged model (15-30GB+)
+  save_merged: false
+  merged_path: "./merged_model"
+
+  # Push to HuggingFace Hub (requires HF_TOKEN env var or hf_token below)
+  # hf_repo: "your-username/your-model-name"
+  # hf_token: ""  # Or set HF_TOKEN environment variable

--- a/finetune/finetune.py
+++ b/finetune/finetune.py
@@ -1,0 +1,239 @@
+"""
+Fine-tuning script using Unsloth + LoRA for gLLM.
+
+Usage:
+    python finetune.py --config config.yaml
+
+Designed to run inside the unsloth/unsloth Docker container.
+Saves LoRA adapters locally and optionally pushes to HuggingFace Hub.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import torch
+import yaml
+from datasets import load_dataset, Dataset
+from unsloth import FastLanguageModel
+from trl import SFTTrainer
+from transformers import TrainingArguments
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def load_config(config_path: str) -> dict:
+    """Load training configuration from YAML file."""
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+    logger.info("Loaded config from %s", config_path)
+    return config
+
+
+def load_model(config: dict):
+    """Load base model with Unsloth optimizations."""
+    model_config = config["model"]
+
+    logger.info("Loading model: %s", model_config["name"])
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=model_config["name"],
+        max_seq_length=model_config.get("max_seq_length", 2048),
+        dtype=None,  # auto-detect
+        load_in_4bit=model_config.get("load_in_4bit", True),
+    )
+
+    # Add LoRA adapter
+    lora_config = config.get("lora", {})
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=lora_config.get("r", 16),
+        target_modules=lora_config.get("target_modules", [
+            "q_proj", "k_proj", "v_proj", "o_proj",
+            "gate_proj", "up_proj", "down_proj",
+        ]),
+        lora_alpha=lora_config.get("lora_alpha", 16),
+        lora_dropout=0,
+        bias="none",
+        use_gradient_checkpointing=True,
+        random_state=lora_config.get("random_state", 3407),
+        max_seq_length=model_config.get("max_seq_length", 2048),
+    )
+
+    logger.info("Model loaded with LoRA (r=%d, alpha=%d)", lora_config.get("r", 16), lora_config.get("lora_alpha", 16))
+    return model, tokenizer
+
+
+def prepare_dataset(config: dict, tokenizer) -> Dataset:
+    """Load and format the training dataset."""
+    data_config = config["dataset"]
+
+    prompt_template = data_config.get("prompt_template", (
+        "Below is an instruction that describes a task, paired with an input "
+        "that provides further context. Write a response that appropriately "
+        "completes the request.\n\n"
+        "### Instruction:\n{instruction}\n\n"
+        "### Input:\n{input}\n\n"
+        "### Response:\n{output}"
+    ))
+
+    # Load from HuggingFace or local file
+    source = data_config["source"]
+    if source.endswith(".json") or source.endswith(".jsonl"):
+        logger.info("Loading dataset from local file: %s", source)
+        dataset = load_dataset("json", data_files=source, split="train")
+    elif source.endswith(".csv"):
+        logger.info("Loading dataset from CSV: %s", source)
+        dataset = load_dataset("csv", data_files=source, split="train")
+    else:
+        logger.info("Loading dataset from HuggingFace: %s", source)
+        split = data_config.get("split", "train")
+        dataset = load_dataset(source, split=split)
+
+    # Format with prompt template
+    instruction_col = data_config.get("instruction_column", "instruction")
+    input_col = data_config.get("input_column", "input")
+    output_col = data_config.get("output_column", "output")
+
+    def format_prompts(examples):
+        texts = []
+        for i in range(len(examples[instruction_col])):
+            text = prompt_template.format(
+                instruction=examples[instruction_col][i],
+                input=examples[input_col][i] if input_col in examples else "",
+                output=examples[output_col][i],
+            )
+            texts.append(text)
+        return {"text": texts}
+
+    dataset = dataset.map(format_prompts, batched=True)
+
+    # Optionally limit dataset size
+    max_samples = data_config.get("max_samples")
+    if max_samples and max_samples < len(dataset):
+        dataset = dataset.select(range(max_samples))
+
+    logger.info("Dataset prepared: %d samples", len(dataset))
+    return dataset
+
+
+def train(model, tokenizer, dataset, config: dict):
+    """Run the fine-tuning training loop."""
+    train_config = config.get("training", {})
+    model_config = config["model"]
+
+    args = TrainingArguments(
+        per_device_train_batch_size=train_config.get("batch_size", 2),
+        gradient_accumulation_steps=train_config.get("gradient_accumulation_steps", 4),
+        warmup_steps=train_config.get("warmup_steps", 5),
+        max_steps=train_config.get("max_steps", -1),
+        num_train_epochs=train_config.get("num_epochs", 3),
+        learning_rate=float(train_config.get("learning_rate", 2e-4)),
+        fp16=not torch.cuda.is_bf16_supported(),
+        bf16=torch.cuda.is_bf16_supported(),
+        logging_steps=train_config.get("logging_steps", 10),
+        optim=train_config.get("optimizer", "adamw_8bit"),
+        weight_decay=train_config.get("weight_decay", 0.01),
+        lr_scheduler_type=train_config.get("lr_scheduler", "linear"),
+        seed=train_config.get("seed", 3407),
+        output_dir=train_config.get("output_dir", "./outputs"),
+        save_strategy=train_config.get("save_strategy", "epoch"),
+        report_to="none",
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        train_dataset=dataset,
+        dataset_text_field="text",
+        max_seq_length=model_config.get("max_seq_length", 2048),
+        args=args,
+    )
+
+    logger.info("Starting training...")
+    stats = trainer.train()
+    logger.info("Training complete. Loss: %.4f", stats.training_loss)
+
+    return trainer, stats
+
+
+def save_adapter(model, tokenizer, config: dict):
+    """Save LoRA adapter locally and optionally push to HuggingFace."""
+    save_config = config.get("save", {})
+    output_path = save_config.get("local_path", "./lora_adapter")
+
+    # Save LoRA adapter locally
+    logger.info("Saving LoRA adapter to %s", output_path)
+    model.save_pretrained(output_path)
+    tokenizer.save_pretrained(output_path)
+
+    # Optionally save merged model
+    if save_config.get("save_merged", False):
+        merged_path = save_config.get("merged_path", "./merged_model")
+        logger.info("Saving merged 16-bit model to %s", merged_path)
+        model.save_pretrained_merged(merged_path, tokenizer, save_method="merged_16bit")
+
+    # Optionally push to HuggingFace Hub
+    hf_repo = save_config.get("hf_repo")
+    hf_token = save_config.get("hf_token") or os.getenv("HF_TOKEN")
+
+    if hf_repo and hf_token:
+        logger.info("Pushing LoRA adapter to HuggingFace: %s", hf_repo)
+        model.push_to_hub_merged(
+            hf_repo, tokenizer,
+            save_method="lora",
+            token=hf_token,
+        )
+        logger.info("Successfully pushed to %s", hf_repo)
+    elif hf_repo:
+        logger.warning("HF_TOKEN not set. Skipping push to HuggingFace.")
+
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fine-tune an LLM with Unsloth + LoRA")
+    parser.add_argument(
+        "--config", type=str, default="config.yaml",
+        help="Path to training configuration YAML file",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    # Load model + LoRA
+    model, tokenizer = load_model(config)
+
+    # Prepare dataset
+    dataset = prepare_dataset(config, tokenizer)
+
+    # Train
+    trainer, stats = train(model, tokenizer, dataset, config)
+
+    # Save adapter
+    output_path = save_adapter(model, tokenizer, config)
+
+    # Save training metadata
+    metadata = {
+        "base_model": config["model"]["name"],
+        "lora_r": config.get("lora", {}).get("r", 16),
+        "lora_alpha": config.get("lora", {}).get("lora_alpha", 16),
+        "dataset": config["dataset"]["source"],
+        "training_loss": stats.training_loss,
+        "epochs": config.get("training", {}).get("num_epochs", 3),
+    }
+    metadata_path = os.path.join(output_path, "training_metadata.json")
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    logger.info("Fine-tuning complete! Adapter saved to: %s", output_path)
+    logger.info("Training metadata: %s", json.dumps(metadata, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/finetune/run_finetune.sh
+++ b/finetune/run_finetune.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Run fine-tuning inside the Unsloth Docker container.
+#
+# Usage:
+#   ./run_finetune.sh                    # Use default config.yaml
+#   ./run_finetune.sh my_config.yaml     # Use custom config
+#
+# Prerequisites:
+#   - Docker with NVIDIA Container Toolkit
+#   - NVIDIA GPU with sufficient VRAM (16GB+ recommended)
+#   - HF_TOKEN env var set (if pushing to HuggingFace)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_FILE="${1:-config.yaml}"
+
+# Load HF_TOKEN from .env if it exists
+if [ -f "$SCRIPT_DIR/../src/.env" ]; then
+    source "$SCRIPT_DIR/../src/.env"
+fi
+
+echo "========================================"
+echo "  gLLM Fine-Tuning with Unsloth + LoRA"
+echo "========================================"
+echo "Config: $CONFIG_FILE"
+echo "GPU:    $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'not detected')"
+echo ""
+
+# Run fine-tuning in Unsloth container
+sudo docker run --rm \
+    --runtime nvidia \
+    --gpus all \
+    -v "$SCRIPT_DIR":/workspace/finetune \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    -e "HF_TOKEN=${HF_TOKEN:-}" \
+    -w /workspace/finetune \
+    --ipc=host \
+    unsloth/unsloth:latest \
+    python finetune.py --config "$CONFIG_FILE"
+
+echo ""
+echo "Fine-tuning complete!"
+echo "LoRA adapter saved to: $SCRIPT_DIR/lora_adapter/"

--- a/src/routers/finetuningrouter.py
+++ b/src/routers/finetuningrouter.py
@@ -1,0 +1,147 @@
+"""API endpoints for managing LoRA adapters and fine-tuning."""
+
+import logging
+import os
+from pathlib import Path
+from typing import Annotated, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
+from src.schema.models import User
+from src.services.authservice import get_current_active_user
+
+logger = logging.getLogger(__name__)
+
+FineTuningRouter = APIRouter(prefix="/finetune", tags=["fine-tuning"])
+
+VLLM_BASE_URL = os.getenv("VLLM_BASE_URL", "http://localhost:8000")
+ADAPTERS_DIR = Path(__file__).resolve().parent.parent.parent / "finetune" / "lora_adapter"
+
+
+# --- Models ---
+
+class AdapterInfo(BaseModel):
+    name: str
+    path: str
+    loaded: bool = False
+
+
+class LoadAdapterRequest(BaseModel):
+    adapter_name: str
+    adapter_path: Optional[str] = None  # defaults to finetune/lora_adapter
+
+
+class AdapterResponse(BaseModel):
+    message: str
+    adapter_name: str
+
+
+# --- Endpoints ---
+
+@FineTuningRouter.get("/adapters", response_model=list[AdapterInfo])
+async def list_adapters(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    """List available LoRA adapters on disk."""
+    adapters = []
+    base_dir = ADAPTERS_DIR.parent
+
+    if not base_dir.exists():
+        return adapters
+
+    # Check for adapter directories (contain adapter_config.json)
+    for item in base_dir.iterdir():
+        if item.is_dir() and (item / "adapter_config.json").exists():
+            adapters.append(AdapterInfo(
+                name=item.name,
+                path=str(item),
+                loaded=False,
+            ))
+
+    # Also check the default lora_adapter path
+    if ADAPTERS_DIR.exists() and (ADAPTERS_DIR / "adapter_config.json").exists():
+        if not any(a.path == str(ADAPTERS_DIR) for a in adapters):
+            adapters.append(AdapterInfo(
+                name="lora_adapter",
+                path=str(ADAPTERS_DIR),
+                loaded=False,
+            ))
+
+    return adapters
+
+
+@FineTuningRouter.post("/adapters/load", response_model=AdapterResponse)
+async def load_adapter(
+    request: LoadAdapterRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    """Load a LoRA adapter into the running vLLM server."""
+    adapter_path = request.adapter_path or str(ADAPTERS_DIR)
+
+    if not Path(adapter_path).exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Adapter path not found: {adapter_path}",
+        )
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{VLLM_BASE_URL}/v1/load_lora_adapter",
+                json={
+                    "lora_name": request.adapter_name,
+                    "lora_path": adapter_path,
+                },
+                timeout=30.0,
+            )
+
+        if resp.status_code == 200:
+            logger.info("Loaded LoRA adapter '%s' from %s", request.adapter_name, adapter_path)
+            return AdapterResponse(
+                message=f"Adapter '{request.adapter_name}' loaded successfully.",
+                adapter_name=request.adapter_name,
+            )
+        else:
+            raise HTTPException(
+                status_code=resp.status_code,
+                detail=f"vLLM error: {resp.text}",
+            )
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Cannot connect to vLLM server. Is it running with --enable-lora?",
+        )
+
+
+@FineTuningRouter.post("/adapters/unload", response_model=AdapterResponse)
+async def unload_adapter(
+    request: LoadAdapterRequest,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    """Unload a LoRA adapter from the running vLLM server."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{VLLM_BASE_URL}/v1/unload_lora_adapter",
+                json={"lora_name": request.adapter_name},
+                timeout=30.0,
+            )
+
+        if resp.status_code == 200:
+            logger.info("Unloaded LoRA adapter '%s'", request.adapter_name)
+            return AdapterResponse(
+                message=f"Adapter '{request.adapter_name}' unloaded successfully.",
+                adapter_name=request.adapter_name,
+            )
+        else:
+            raise HTTPException(
+                status_code=resp.status_code,
+                detail=f"vLLM error: {resp.text}",
+            )
+    except httpx.ConnectError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Cannot connect to vLLM server.",
+        )

--- a/src/server.py
+++ b/src/server.py
@@ -11,6 +11,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from src.core.core import oauth2_scheme
 from src.routers.adminrouter import AdminRouter
 from src.routers.authrouter import AuthRouter
+from src.routers.finetuningrouter import FineTuningRouter
 from src.services.authservice import require_roles
 from src.schema.models import UserRole
 
@@ -21,6 +22,13 @@ app.include_router(AuthRouter)
 app.include_router(
     AdminRouter,
     dependencies=[Depends(oauth2_scheme), Depends(require_roles(UserRole.admin))],
+)
+app.include_router(
+    FineTuningRouter,
+    dependencies=[
+        Depends(oauth2_scheme),
+        Depends(require_roles(UserRole.admin, UserRole.fine_tuner)),
+    ],
 )
 mount_chainlit(app=app, target="./chainlit-app.py", path="/gllm")
 

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -1,0 +1,143 @@
+"""Unit tests for fine-tuning config loading and API endpoints."""
+
+import os
+import sys
+import json
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from pathlib import Path
+
+# Add src and finetune to path
+src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
+finetune_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../finetune"))
+sys.path.insert(0, src_path)
+sys.path.insert(0, finetune_path)
+
+
+class TestFineTuneConfig:
+    """Tests for the fine-tuning configuration."""
+
+    def test_config_yaml_is_valid(self):
+        import yaml
+
+        config_path = os.path.join(finetune_path, "config.yaml")
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        assert "model" in config
+        assert "name" in config["model"]
+        assert "lora" in config
+        assert "r" in config["lora"]
+        assert "dataset" in config
+        assert "source" in config["dataset"]
+        assert "training" in config
+        assert "save" in config
+
+    def test_config_has_reasonable_defaults(self):
+        import yaml
+
+        config_path = os.path.join(finetune_path, "config.yaml")
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        # LoRA rank should be reasonable
+        assert config["lora"]["r"] in [4, 8, 16, 32, 64, 128]
+
+        # Learning rate should be reasonable
+        lr = float(config["training"]["learning_rate"])
+        assert 1e-6 <= lr <= 1e-2
+
+        # Batch size should be positive
+        assert config["training"]["batch_size"] > 0
+
+    def test_config_model_is_unsloth_compatible(self):
+        import yaml
+
+        config_path = os.path.join(finetune_path, "config.yaml")
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        # Model name should be a string
+        assert isinstance(config["model"]["name"], str)
+        assert len(config["model"]["name"]) > 0
+
+
+class TestFineTuneScript:
+    """Tests for the fine-tuning script's config loader."""
+
+    def test_load_config(self):
+        # We can't import the full finetune.py (requires torch/unsloth),
+        # but we can test the YAML loading logic
+        import yaml
+
+        config_path = os.path.join(finetune_path, "config.yaml")
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        assert config is not None
+        assert isinstance(config, dict)
+
+    def test_prompt_template_has_placeholders(self):
+        import yaml
+
+        config_path = os.path.join(finetune_path, "config.yaml")
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        template = config["dataset"].get("prompt_template", "")
+        assert "{instruction}" in template
+        assert "{input}" in template
+        assert "{output}" in template
+
+
+class TestFineTuningRouter:
+    """Tests for the fine-tuning API endpoints."""
+
+    ENV_OVERRIDES = {
+        "AUTH_SECRET": "test-secret-key",
+        "HASH_ALGORITHM": "HS256",
+        "ACCESS_TOKEN_EXPIRE_MINUTES": "30",
+        "DATABASE_URL": "postgresql://test:test@localhost/test",
+        "BUCKET_NAME": "test",
+        "APP_AWS_ACCESS_KEY": "test",
+        "APP_AWS_SECRET_KEY": "test",
+        "APP_AWS_REGION": "us-east-1",
+        "CHAINLIT_AUTH_SECRET": "test",
+    }
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_list_adapters_returns_empty_when_no_adapters(self):
+        from src.routers.finetuningrouter import list_adapters
+
+        # The function is async, but we can test the logic
+        # by checking that ADAPTERS_DIR is set correctly
+        from src.routers.finetuningrouter import ADAPTERS_DIR
+        assert "finetune" in str(ADAPTERS_DIR)
+        assert "lora_adapter" in str(ADAPTERS_DIR)
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_adapter_info_model(self):
+        from src.routers.finetuningrouter import AdapterInfo
+
+        adapter = AdapterInfo(name="test", path="/tmp/test", loaded=False)
+        assert adapter.name == "test"
+        assert adapter.loaded is False
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_load_adapter_request_model(self):
+        from src.routers.finetuningrouter import LoadAdapterRequest
+
+        req = LoadAdapterRequest(adapter_name="my_adapter")
+        assert req.adapter_name == "my_adapter"
+        assert req.adapter_path is None
+
+        req2 = LoadAdapterRequest(adapter_name="custom", adapter_path="/tmp/custom")
+        assert req2.adapter_path == "/tmp/custom"
+
+    @patch.dict(os.environ, ENV_OVERRIDES)
+    def test_adapter_response_model(self):
+        from src.routers.finetuningrouter import AdapterResponse
+
+        resp = AdapterResponse(message="Loaded", adapter_name="test")
+        assert resp.message == "Loaded"
+        assert resp.adapter_name == "test"

--- a/vllmconfig/vllminit_lora.sh
+++ b/vllmconfig/vllminit_lora.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Start vLLM with LoRA adapter support enabled.
+#
+# Usage:
+#   ./vllminit_lora.sh                           # Base model only, LoRA ready
+#   ./vllminit_lora.sh /path/to/lora_adapter     # Load a LoRA adapter at startup
+#
+# At runtime, you can load/unload LoRA adapters via the API:
+#   curl -X POST http://localhost:8000/v1/load_lora_adapter \
+#     -H "Content-Type: application/json" \
+#     -d '{"lora_name": "my_adapter", "lora_path": "/adapters/my_adapter"}'
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Load env vars
+if [ -f "$SCRIPT_DIR/../src/.env" ]; then
+    source "$SCRIPT_DIR/../src/.env"
+fi
+
+PORT=8000
+GPU_MEMORY_UTILIZATION=0.9
+dtype=auto
+LOG_FILE="$SCRIPT_DIR/vllm-logs/vllm.log"
+LORA_ADAPTER_PATH="${1:-}"
+ADAPTERS_DIR="$SCRIPT_DIR/../finetune/lora_adapter"
+
+mkdir -p "$SCRIPT_DIR/vllm-logs"
+
+# Build LoRA arguments
+LORA_ARGS=""
+if [ -n "$LORA_ADAPTER_PATH" ]; then
+    ADAPTER_NAME=$(basename "$LORA_ADAPTER_PATH")
+    LORA_ARGS="--enable-lora --max-loras 4 --max-lora-rank 64 --lora-modules {\"name\":\"$ADAPTER_NAME\",\"path\":\"/adapters/$ADAPTER_NAME\",\"base_model_name\":\"$MODEL\"}"
+    VOLUME_ARGS="-v $LORA_ADAPTER_PATH:/adapters/$ADAPTER_NAME"
+else
+    LORA_ARGS="--enable-lora --max-loras 4 --max-lora-rank 64"
+    VOLUME_ARGS=""
+    # Mount default adapters directory if it exists
+    if [ -d "$ADAPTERS_DIR" ]; then
+        VOLUME_ARGS="-v $ADAPTERS_DIR:/adapters/default"
+    fi
+fi
+
+echo "========================================"
+echo "  vLLM with LoRA Support"
+echo "========================================"
+echo "Model:   $MODEL"
+echo "Port:    $PORT"
+echo "LoRA:    enabled (max 4 adapters, max rank 64)"
+echo "Adapter: ${LORA_ADAPTER_PATH:-none (load at runtime via API)}"
+echo ""
+
+# Allow runtime LoRA loading/unloading
+export VLLM_ALLOW_RUNTIME_LORA_UPDATING=True
+
+sudo docker run --runtime nvidia --gpus all \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    $VOLUME_ARGS \
+    --env "HUGGING_FACE_HUB_TOKEN=$HF_TOKEN" \
+    --env "VLLM_ALLOW_RUNTIME_LORA_UPDATING=True" \
+    -p $PORT:8000 \
+    --ipc=host \
+    vllm/vllm-openai:latest \
+    --model $MODEL \
+    --host 0.0.0.0 \
+    --trust-remote-code \
+    --served-model-name $MODEL \
+    --swap-space 0 \
+    --dtype $dtype \
+    --gpu-memory-utilization $GPU_MEMORY_UTILIZATION \
+    --max-model-len 32768 \
+    $LORA_ARGS \
+    2>&1 | tee "$LOG_FILE"


### PR DESCRIPTION
## Summary
- **Fine-tuning script** (`finetune/finetune.py`) using Unsloth + QLoRA for 2x faster training with 70% less VRAM
- **YAML config** (`finetune/config.yaml`) for model, LoRA params, dataset, and training settings
- **Docker runner** (`finetune/run_finetune.sh`) to run fine-tuning inside the `unsloth/unsloth` container
- **vLLM LoRA serving** (`vllmconfig/vllminit_lora.sh`) with runtime hot-swapping of adapters
- **Backend API** (`/finetune/adapters`) for listing, loading, and unloading LoRA adapters (admin + fine_tuner roles only)
- **9 unit tests** for config validation and API models

Relates to #14

## Architecture

```
finetune/
├── finetune.py          # Training script (runs in Unsloth Docker)
├── config.yaml          # Training configuration
├── run_finetune.sh      # Docker launch script
├── README.md            # Usage guide
└── .gitignore           # Ignore model outputs

vllmconfig/
└── vllminit_lora.sh     # vLLM with LoRA support

src/routers/
└── finetuningrouter.py  # API for adapter management
```

## Workflow

1. Edit `config.yaml` (model, dataset, LoRA params)
2. Run `./finetune/run_finetune.sh` → trains in Docker, saves adapter to `finetune/lora_adapter/`
3. Either:
   - Start vLLM with adapter: `./vllmconfig/vllminit_lora.sh ./finetune/lora_adapter`
   - Or load at runtime via API: `POST /finetune/adapters/load`
4. Optionally push adapter to HuggingFace (set `hf_repo` in config)

## Test plan
- [x] 9 unit tests pass for config validation and API models
- [ ] Manual test: run fine-tuning with a small dataset (max_steps: 20)
- [ ] Manual test: load LoRA adapter into vLLM via API
- [ ] Manual test: verify chat uses the fine-tuned adapter
- [ ] Manual test: unload adapter and verify fallback to base model

🤖 Generated with [Claude Code](https://claude.com/claude-code)